### PR TITLE
Increase the recursion limit and add smoothing to the weighted games

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -2,6 +2,17 @@ import matplotlib.pyplot as plt
 from matplotlib import animation
 
 
+def smooth(values, weight):
+    last = values[0]
+    smoothed = list()
+    for point in values:
+        smoothed_val = last * weight + (1 - weight) * point
+        smoothed.append(smoothed_val)
+        last = smoothed_val
+
+    return smoothed
+
+
 class Graph:
     def __init__(self, main):
         self.main = main
@@ -22,7 +33,6 @@ class Graph:
         self.ax3 = plt.axes()
         self.ax3.set_xlabel("games")
         self.ax3.set_ylabel("weighted average")
-
 
     def show(self):
         self.anim = animation.FuncAnimation(self.fig, self.animate, interval=1000)
@@ -47,8 +57,8 @@ class Graph:
 
         plt.figure(3)
         self.ax3.clear()
-        for i in self.main.menace.weighted_win_loss:
-            self.ax3.plot(i)
-        self.ax3.set_xlabel("games")
-        self.ax3.set_ylabel("weighted average")
-
+        if len(self.main.menace.win_loss_over_time) > 5:
+            for i in self.main.menace.weighted_win_loss:
+                self.ax3.plot(smooth(i, 0.7))
+            self.ax3.set_xlabel("games")
+            self.ax3.set_ylabel("weighted average")

--- a/menace.py
+++ b/menace.py
@@ -4,6 +4,7 @@ import simulations
 
 import time
 import json
+import sys
 
 
 class Menace:
@@ -27,6 +28,8 @@ class Menace:
         self.losses_over_time = []
         self.win_loss_over_time = []
         self.weighted_win_loss = [[], [], []]
+
+        sys.setrecursionlimit(10000)
 
         self.initial_first_box_beads = sum(self.all_boxes[0].beads) # To allow for calculation of change of beads
 


### PR DESCRIPTION
Sorry, was going to add this commit to the last pull request, but you merged it too quickly.

From by testing it was interesting going over 1000 games which requires over 1000 recursions.
The smoothing means that it looks a lot cleaner.